### PR TITLE
Fallback TEMPS_DIR to tempfile.gettempdir

### DIFF
--- a/temps.py
+++ b/temps.py
@@ -62,11 +62,12 @@ import contextlib
 import os
 import shutil
 import uuid
+from tempfile import gettempdir
 
 
 # SET THE DEFAULTS
 
-TEMPS_DIR = os.environ.get('TEMPS_DIR') or os.getcwd()
+TEMPS_DIR = os.environ.get('TEMPS_DIR') or gettempdir()
 TEMPS_PREFIX = os.environ.get('TEMPS_PREFIX', '')
 TEMPS_SUFFIX = os.environ.get('TEMPS_SUFFIX', '')
 TEMPS_MODE = int(os.environ.get('TEMPS_MODE', '0777'), 8)

--- a/tests/test_temps.py
+++ b/tests/test_temps.py
@@ -1,8 +1,10 @@
-
-
-
 import temps
 import os
+from subprocess import Popen
+from subprocess import PIPE
+from nose.tools import eq_
+from tempfile import gettempdir
+from shutil import rmtree
 
 def test_tmpfile():
     with temps.tmpfile() as path:
@@ -34,4 +36,50 @@ def test_tmppath():
         if os.path.isdir(path):
             os.rmdir(path)
 
+class TestTempsDir:
+    def _popen(self, overrides=None):
+        """
+        :type override: (str, str)
+        :param override: (var, val)
+        """
 
+        if not overrides:
+            overrides = []
+
+        p = Popen(
+            ["env", "-i"]
+            + ["=".join(xs) for xs in overrides]
+            + ["python", "-c", "import temps; print temps.TEMPS_DIR;"]
+            , stdout=PIPE, stderr=PIPE
+        )
+        out, _ = p.communicate()
+        return out.strip()
+
+    def setUp(self):
+        self.tmpdir = '/tmp/foo'
+        os.makedirs(self.tmpdir)
+        # L{tempfile.gettempdir} checks wheter the dir is
+        # readable/writable, if not it continues fallbacking
+
+    def tearDown(self):
+        rmtree(self.tmpdir)
+
+    def test_pure_fallback(self):
+        """
+        Test we get the `gettempdir`s platform specific fallback when
+        give no env overrides
+        """
+        eq_(self._popen(), gettempdir())
+
+    def test_gettempdir_env_var(self):
+        """
+        Test we get an override handled by `gettempdir`
+        """
+        eq_(self._popen([("TMP", self.tmpdir)]), self.tmpdir)
+
+    def test_temps_env_var(self):
+        """
+        Test we get an override for temps itself
+        """
+        v = "/foo2"
+        eq_(self._popen(dict(TMP = self.tmpdir, TEMPS_DIR = v).items()), v)


### PR DESCRIPTION
So it fallbacks sensibly to environment variables TMPDIR, TEMP or TMP or
a sensisble platform default like '/tmp' while still being able to be
overriden by env TEMPS_DIR only for this library.
